### PR TITLE
Update to email link in 1.2 How you'll learn

### DIFF
--- a/lessons/1.2-how-you'll-learn.md
+++ b/lessons/1.2-how-you'll-learn.md
@@ -40,6 +40,6 @@ These lessons are intended for beginners so we don't expect you to have any exis
 
 If you get stuck go to the *#ddat-codelabs* channel on the [cross-government digital Slack team](https://ukgovernmentdigital.slack.com/). Your fellow learners and mentors will be in this channel.
 
-If you can't access to that Slack team you can also email the [DDaT Codelabs volunteer team](ddatcodelabs@gmail.com).
+If you can't access to that Slack team you can also email the [DDaT Codelabs volunteer team](mailto:ddatcodelabs@gmail.com).
 
 If you are having trouble with a project task it may be useful to look at the code for an example app we built. You can copy this code if you need to - but we recommend writing your own.


### PR DESCRIPTION
Existing link didn't include a mailto: protocol, and so was trying to direct to a sub-page of the existing site with the email address as the filename.

BTW fab both to see this tutorial, and to see it editable on github. Great work to the team getting it published, will be nudging colleagues at gov.wales towards this :)